### PR TITLE
nazotteのクエリ発行数を減らす

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/labstack/gommon/log"
 )
 
 const Limit = 20

--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -875,7 +875,11 @@ func searchEstateNazotte(c echo.Context) error {
 	}
 
 	estatesInPolygon := []Estate{}
-	for _, estate := range estatesInBoundingBox {
+	for i, estate := range estatesInBoundingBox {
+		if i >= NazotteLimit {
+			break
+		}
+
 		validatedEstate := Estate{}
 
 		point := fmt.Sprintf("'POINT(%f %f)'", estate.Latitude, estate.Longitude)

--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -874,8 +874,8 @@ func searchEstateNazotte(c echo.Context) error {
 	}
 
 	estatesInPolygon := []Estate{}
-	for i, estate := range estatesInBoundingBox {
-		if i >= NazotteLimit {
+	for _, estate := range estatesInBoundingBox {
+		if len(estatesInPolygon) >= NazotteLimit {
 			break
 		}
 


### PR DESCRIPTION
## score
```
2022/07/18 01:12:05 bench.go:102: 最終的な負荷レベル: 6
{"pass":true,"score":1141,"messages":[{"text":"POST /api/estate/nazotte: リクエストに失敗しました (タイムアウトしました)","count":28}],"reason":"OK","language":"go"}
```